### PR TITLE
Fix entry meta related PHP warning during form submission

### DIFF
--- a/gfeloqua.class.php
+++ b/gfeloqua.class.php
@@ -1623,7 +1623,7 @@ class GFEloqua extends GFFeedAddOn {
 			return $entry_meta;
 		}
 
-		$meta[ GFELOQUA_OPT_PREFIX . 'success' ] = array(
+		$entry_meta[ GFELOQUA_OPT_PREFIX . 'success' ] = array(
 			'label'             => __( 'Sent to Eloqua?', 'gfeloqua' ),
 			'is_numeric'        => false,
 			'is_default_column' => false

--- a/gfeloqua.class.php
+++ b/gfeloqua.class.php
@@ -98,8 +98,6 @@ class GFEloqua extends GFFeedAddOn {
 		// entry detail
 		add_action( 'gform_entry_detail', array( $this, 'entry_notes' ), 10, 2 );
 
-		// entry meta (for column)
-		add_action( 'gform_entry_meta', array( $this, 'add_success_meta' ), 10, 2 );
 	}
 
 	/**
@@ -1610,20 +1608,28 @@ class GFEloqua extends GFFeedAddOn {
 		gform_update_meta( $entry_id, GFELOQUA_OPT_PREFIX . 'retries', $attempts, $form_id );
 	}
 
-	function add_success_meta( $meta, $form_id ){
-		$feeds = GFAPI::get_feeds( NULL, $form_id, $this->_slug );
+	/**
+	 * Add the "Sent to Eloqua" entry meta property.
+	 *
+	 * @param array $entry_meta An array of entry meta already registered with the gform_entry_meta filter.
+	 * @param int $form_id The id of the current form.
+	 *
+	 * @return array
+	 */
+	public function get_entry_meta( $entry_meta, $form_id ) {
+		$feeds = $this->get_feeds();
 
-		if( ! $feeds )
-			return $meta;
+		if ( ! $feeds ) {
+			return $entry_meta;
+		}
 
-		$meta[ GFELOQUA_OPT_PREFIX . 'success'] = array(
-			'label' => __( 'Sent to Eloqua?', 'gfeloqua' ),
-			'is_numeric' => false,
-			'update_entry_meta_callback' => 'update_entry_meta',
+		$meta[ GFELOQUA_OPT_PREFIX . 'success' ] = array(
+			'label'             => __( 'Sent to Eloqua?', 'gfeloqua' ),
+			'is_numeric'        => false,
 			'is_default_column' => false
 		);
 
-		return $meta;
+		return $entry_meta;
 	}
 
 	function add_extra_cron_schedule( $schedules ){

--- a/gravityforms-eloqua.plugin.php
+++ b/gravityforms-eloqua.plugin.php
@@ -3,14 +3,14 @@
  * Plugin Name: Gravity Forms Eloqua
  * Plugin URI: http://www.briandichiara.com
  * Description: Integrate Eloqua into Gravity Forms
- * Version: 1.5.1
+ * Version: 1.5.2
  * Author: Brian DiChiara
  * Author URI: http://www.briandichiara.com
  * GitHub Plugin URI: https://github.com/solepixel/gravityforms-eloqua
  * GitHub Branch: master
  */
 
-define( 'GFELOQUA_VERSION', '1.5.1' );
+define( 'GFELOQUA_VERSION', '1.5.2' );
 define( 'GFELOQUA_OPT_PREFIX', 'gfeloqua_' );
 define( 'GFELOQUA_PATH', plugin_dir_path( __FILE__ ) );
 define( 'GFELOQUA_DIR', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,9 @@ Nobody has asked any questions frequently.
 No screenshots at this time.
 
 == Upgrade Notice ==
+= 1.5.2 =
+* Fixed a PHP warning which would occur when the entry meta was being processed during submission.
+
 = 1.5.1 =
 * Fixed a bug when refreshing OAuth token
 * FIxed a bug with admin notification


### PR DESCRIPTION
This fixes the issue reported by @baroquedesign in the latest comment on issue #11.

As you don't need the entry meta item to have a value set when the entry is being created the update_entry_meta_callback can be removed from the array.

I also switched it to using the add-on frameworks own get_entry_meta method for adding the meta item.