### PR TITLE
Added hook for debug information

### DIFF
--- a/gfeloqua.class.php
+++ b/gfeloqua.class.php
@@ -1410,6 +1410,9 @@ class GFEloqua extends GFFeedAddOn {
 		$notes = array_merge( $notes, $new_notes );
 
 		gform_update_meta( $entry_id, GFELOQUA_OPT_PREFIX . 'notes', $notes, $form_id );
+
+		// Added hook to allow custom error logging.
+		do_action( 'gravityforms_eloqua_log_entry_notes', $this->debugger, $entry_id, $form_id );
 	}
 
 	/**

--- a/gfeloqua.class.php
+++ b/gfeloqua.class.php
@@ -1412,7 +1412,7 @@ class GFEloqua extends GFFeedAddOn {
 		gform_update_meta( $entry_id, GFELOQUA_OPT_PREFIX . 'notes', $notes, $form_id );
 
 		// Added hook to allow custom error logging.
-		do_action( 'gravityforms_eloqua_log_entry_notes', $this->debugger, $entry_id, $form_id );
+		do_action( 'gfeloqua_eloqua_log_entry_notes', $this->debugger, $entry_id, $form_id );
 	}
 
 	/**


### PR DESCRIPTION
It is possible to disable the storage of form entries in Gravity Forms, and many clients wish to do this as they do not want to store the entries in two places.

If this is the case the notes will not be saved to the entry, so I have added a simple hook to allow developers to hook in and log the errors how they please.